### PR TITLE
Adding Support for FlexiPages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [1.0.1] - 2025-08-01
+
+### ✨ Added
+
+- ⚡ **FlexiPage support** (Lightning App Builder):
+
+  - Right-click `.flexipage-meta.xml` to open in:
+
+    - **Edit Mode** (App Builder)
+    - **View Mode** (FlexiPage Setup)
+
+  - Full support for Command Palette and file context menu
+
+- ⚙️ **Custom edit URL builder for FlexiPages**:
+
+  - Mirrors the behavior of SObjects: uses `retUrl` to redirect users back to the FlexiPage list after edit
+
+- 🧩 **New `openFileSupportedMetadataTypes` setting**:
+
+  - Works in conjunction with `useOpenFileCommandToOpenMetadata`
+  - Allows selecting _which_ types (e.g., `Flow`, `FlexiPage`) use `sf org open --source-file`
+  - Fully configurable per type (default: `["Flow", "FlexiPage"]`)
+
+### 🔄 Changed
+
+- 🧠 `mustUseOpenFileCommand()` now validates against:
+
+  - CLI mode (`edit` only)
+  - Global toggle (`useOpenFileCommandToOpenMetadata`)
+  - User-selected types (`openFileSupportedMetadataTypes`)
+  - Internal file support flag
+
+- 🧼 Improved descriptions for related settings in `package.json`:
+
+  - Clearer relationship between global toggle and type list
+  - Marked both as _EDIT-mode only_
+
+- ✅ `DeployableMetadataKeys` and settings updated to include `"FlexiPage"`
+
+### 🧼 Internal
+
+- 🧩 Added `src/openers/flexipage/` module with:
+
+  - `registerHandlers()`
+  - `retrieveRecord()` using Tooling API
+  - `resolvePath()` with retUrl support
+  - Full typing in `model.ts`
+
+- 🔗 Updated `extension.ts` and manifest files to auto-register FlexiPage commands
+
+- 📋 Menu conditions and activation events added for `.flexipage-meta.xml`
+
+---
+
 ## [1.0.0] - 2025-07-31
 
 ### ✨ Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ From the Command Palette:
 
 ---
 
+## 📦 Salesforce Metadata Opener on VS Marketplace
+
+→ [Install Salesforce Metadata Opener](https://marketplace.visualstudio.com/items?itemName=MatheusGoncalves.sf-metadata-opener)
+
+---
+
 ## 📣 Feedback
 
 → [Open an issue](https://github.com/gitmatheus/sf-metadata-opener/issues)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A sleek, no-friction way to open Salesforce metadata directly in your browser, r
 
 Currently supports:
 
-- ✅ **Flows**
 - ✅ **Agentforce Agents (Bots)**
-- ✅ **Reports**
-- ✅ **Dashboards**
-- ✅ **Validation Rules**
 - ✅ **Custom and Standard Objects**
+- ✅ **Dashboards**
+- ✅ **FlexiPages**
+- ✅ **Flows**
+- ✅ **Reports**
+- ✅ **Validation Rules**
 
 ---
 
@@ -49,14 +50,15 @@ The extension will open the page in Edit or View mode, contextually for each typ
 
 ## 🛠️ Supported Metadata Types
 
-| Metadata Type             | Edit Mode Target   | View Mode Target              |
-| ------------------------- | ------------------ | ----------------------------- |
-| Flow                      | Flow Builder       | Flow View Page (if supported) |
-| Agentforce Agent          | Agentforce Builder | Agent Setup Page              |
-| Report                    | Report Builder     | Report Viewer                 |
-| Dashboard                 | Dashboard Builder  | Dashboard Viewer              |
-| Validation Rule           | Edit in Setup      | Open in Detail Page           |
-| Object (Standard/Custom ) | Edit in Setup      | Open in Detail Page           |
+| Metadata Type             | Edit Mode Target      | View Mode Target              |
+| ------------------------- | --------------------- | ----------------------------- |
+| Agentforce Agent          | Agentforce Builder    | Agent Setup Page              |
+| Dashboard                 | Dashboard Builder     | Dashboard Viewer              |
+| FlexiPage                 | Lightning App Builder | FlexiPage Setup Page          |
+| Flow                      | Flow Builder          | Flow View Page (if supported) |
+| Object (Standard/Custom ) | Edit in Setup         | Open in Detail Page           |
+| Report                    | Report Builder        | Report Viewer                 |
+| Validation Rule           | Edit in Setup         | Open in Detail Page           |
 
 ---
 
@@ -73,7 +75,14 @@ Each type is opt-in. You control exactly which ones to deploy.
 
 > **Default: `true`**
 
-Uses `sf org open --source-file` when supported. If disabled, the extension builds the Lightning URL directly.
+Enable global support for the `sf org open --source-file` CLI. If disabled, the extension always uses an org-based ID URL resolution.
+
+### `Metadata Types That Use CLI`
+
+> **Default: `["Flow", "FlexiPage"]`**
+
+Select which metadata types are allowed to use `sf org open --source-file`.  
+Others will fallback to org-based ID resolution and open via constructed URL.
 
 ### `Enable Caching`
 
@@ -102,8 +111,7 @@ From the Command Palette:
 
 ## 🔮 Coming Soon
 
-- Profiles, Permission Sets, Record Pages, Custom Tabs
-- Deploy preview diagnostics
+- Profiles, Permission Sets, Custom Tabs, and more
 - CLI fallback options for complex metadata
 
 ---

--- a/package.base.json
+++ b/package.base.json
@@ -5,7 +5,7 @@
   "icon": "icon.png",
   "repository": "https://github.com/gitmatheus/sf-metadata-opener",
   "description": "Right-click to open Salesforce metadata in the browser (Flows, Agentforce agents, etc.)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.102.0"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "SalesforceMetadataOpener.useOpenFileCommandToOpenMetadata": {
           "type": "boolean",
           "default": true,
-          "description": "Use the `sf org open --source-file` CLI to open supported metadata in the browser. Disable this to have the extension query the org for the metadata ID instead."
+          "description": "Enable support for the `sf org open --source-file` command. When enabled, metadata types listed above may use this CLI-based method to open in the browser. Disable this entirely to always use the fallback org-based ID resolution instead. Available for EDIT mode only."
         },
         "SalesforceMetadataOpener.openFileSupportedMetadataTypes": {
           "type": "array",
@@ -67,7 +67,7 @@
             "Flow",
             "FlexiPage"
           ],
-          "description": "Select which metadata types should use `sf org open --source-file` to open in the browser.",
+          "description": "Specify which metadata types are eligible to use `sf org open --source-file`. This list is only used when the below setting is enabled. Removing a type here forces the extension to resolve the metadata ID from the org instead. Available for EDIT mode only.",
           "items": {
             "type": "string",
             "enum": [
@@ -95,20 +95,22 @@
           "items": {
             "type": "string",
             "enum": [
-              "Flow",
               "Bot",
-              "Report",
               "Dashboard",
-              "ValidationRule",
-              "SObject"
+              "FlexiPage",
+              "Flow",
+              "Report",
+              "SObject",
+              "ValidationRule"
             ],
             "enumDescriptions": [
-              "Flows",
               "Agentforce Agents (Bots)",
-              "Reports",
               "Dashboards",
-              "Validation Rules",
-              "Standard and Custom Objects"
+              "FlexiPages",
+              "Flows",
+              "Reports",
+              "Standard and Custom Objects",
+              "Validation Rules"
             ]
           }
         }
@@ -148,6 +150,14 @@
         "title": "SFDX: Open Current Dashboard in View Mode"
       },
       {
+        "command": "extension.openCurrentFlexiPageInEditMode",
+        "title": "SFDX: Open Current FlexiPage in Lightning App Builder"
+      },
+      {
+        "command": "extension.openCurrentFlexiPageInViewMode",
+        "title": "SFDX: Open Current FlexiPage Details in Setup"
+      },
+      {
         "command": "extension.openCurrentFlowInEditMode",
         "title": "SFDX: Open Current Flow in Flow Builder"
       },
@@ -169,7 +179,7 @@
       },
       {
         "command": "extension.openCurrentSObjectInViewMode",
-        "title": "SFDX: Open Current SObject in View Mode"
+        "title": "SFDX: Open Current SObject Details in Setup"
       },
       {
         "command": "extension.openCurrentValidationRuleInEditMode",
@@ -177,7 +187,7 @@
       },
       {
         "command": "extension.openCurrentValidationRuleInViewMode",
-        "title": "SFDX: Open Current Validation Rule in View Mode"
+        "title": "SFDX: Open Current Validation Rule Details in Setup"
       },
       {
         "command": "extension.openDashboardInEditMode",
@@ -186,6 +196,14 @@
       {
         "command": "extension.openDashboardInViewMode",
         "title": "SFDX: Open Dashboard in View Mode"
+      },
+      {
+        "command": "extension.openFlexiPageInEditMode",
+        "title": "SFDX: Open FlexiPage in Lightning App Builder"
+      },
+      {
+        "command": "extension.openFlexiPageInViewMode",
+        "title": "SFDX: Open FlexiPage Details in Setup"
       },
       {
         "command": "extension.openFlowInEditMode",
@@ -240,6 +258,16 @@
         {
           "command": "extension.openDashboardInViewMode",
           "when": "resourceFilename =~ /\\.dashboard-meta\\.xml$/",
+          "group": "z_commands"
+        },
+        {
+          "command": "extension.openFlexiPageInEditMode",
+          "when": "resourceFilename =~ /\\.flexipage-meta\\.xml$/",
+          "group": "z_commands"
+        },
+        {
+          "command": "extension.openFlexiPageInViewMode",
+          "when": "resourceFilename =~ /\\.flexipage-meta\\.xml$/",
           "group": "z_commands"
         },
         {
@@ -298,6 +326,14 @@
         },
         {
           "command": "extension.openDashboardInViewMode",
+          "when": "false"
+        },
+        {
+          "command": "extension.openFlexiPageInEditMode",
+          "when": "false"
+        },
+        {
+          "command": "extension.openFlexiPageInViewMode",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "icon.png",
   "repository": "https://github.com/gitmatheus/sf-metadata-opener",
   "description": "Right-click to open Salesforce metadata in the browser (Flows, Agentforce agents, etc.)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.102.0"
   },
@@ -60,6 +60,25 @@
           "type": "boolean",
           "default": true,
           "description": "Use the `sf org open --source-file` CLI to open supported metadata in the browser. Disable this to have the extension query the org for the metadata ID instead."
+        },
+        "SalesforceMetadataOpener.openFileSupportedMetadataTypes": {
+          "type": "array",
+          "default": [
+            "Flow",
+            "FlexiPage"
+          ],
+          "description": "Select which metadata types should use `sf org open --source-file` to open in the browser.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Flow",
+              "FlexiPage"
+            ],
+            "enumDescriptions": [
+              "Flows",
+              "FlexiPages"
+            ]
+          }
         },
         "SalesforceMetadataOpener.enableCaching": {
           "type": "boolean",

--- a/scripts/manifest/commands.json
+++ b/scripts/manifest/commands.json
@@ -31,6 +31,16 @@
     "command": "extension.openCurrentDashboardInViewMode",
     "title": "SFDX: Open Current Dashboard in View Mode"
   },
+
+  {
+    "command": "extension.openCurrentFlexiPageInEditMode",
+    "title": "SFDX: Open Current FlexiPage in Lightning App Builder"
+  },
+  {
+    "command": "extension.openCurrentFlexiPageInViewMode",
+    "title": "SFDX: Open Current FlexiPage Details in Setup"
+  },
+
   {
     "command": "extension.openCurrentFlowInEditMode",
     "title": "SFDX: Open Current Flow in Flow Builder"
@@ -39,6 +49,7 @@
     "command": "extension.openCurrentFlowInViewMode",
     "title": "SFDX: Open Current Flow in View Mode"
   },
+
   {
     "command": "extension.openCurrentReportInEditMode",
     "title": "SFDX: Open Current Report in Edit Mode"
@@ -47,22 +58,25 @@
     "command": "extension.openCurrentReportInViewMode",
     "title": "SFDX: Open Current Report in View Mode"
   },
+
   {
     "command": "extension.openCurrentSObjectInEditMode",
     "title": "SFDX: Open Current SObject in Edit Mode"
   },
   {
     "command": "extension.openCurrentSObjectInViewMode",
-    "title": "SFDX: Open Current SObject in View Mode"
+    "title": "SFDX: Open Current SObject Details in Setup"
   },
+
   {
     "command": "extension.openCurrentValidationRuleInEditMode",
     "title": "SFDX: Open Current Validation Rule in Edit Mode"
   },
   {
     "command": "extension.openCurrentValidationRuleInViewMode",
-    "title": "SFDX: Open Current Validation Rule in View Mode"
+    "title": "SFDX: Open Current Validation Rule Details in Setup"
   },
+
   {
     "command": "extension.openDashboardInEditMode",
     "title": "SFDX: Open Dashboard in Edit Mode"
@@ -71,6 +85,16 @@
     "command": "extension.openDashboardInViewMode",
     "title": "SFDX: Open Dashboard in View Mode"
   },
+
+  {
+    "command": "extension.openFlexiPageInEditMode",
+    "title": "SFDX: Open FlexiPage in Lightning App Builder"
+  },
+  {
+    "command": "extension.openFlexiPageInViewMode",
+    "title": "SFDX: Open FlexiPage Details in Setup"
+  },
+
   {
     "command": "extension.openFlowInEditMode",
     "title": "SFDX: Open Flow in Flow Builder"

--- a/scripts/manifest/contributes.json
+++ b/scripts/manifest/contributes.json
@@ -5,18 +5,19 @@
       "SalesforceMetadataOpener.useOpenFileCommandToOpenMetadata": {
         "type": "boolean",
         "default": true,
-        "description": "Use the `sf org open --source-file` CLI to open supported metadata in the browser. Disable this to have the extension query the org for the metadata ID instead."
+        "description": "Enable support for the `sf org open --source-file` command. When enabled, metadata types listed above may use this CLI-based method to open in the browser. Disable this entirely to always use the fallback org-based ID resolution instead. Available for EDIT mode only."
       },
       "SalesforceMetadataOpener.openFileSupportedMetadataTypes": {
         "type": "array",
         "default": ["Flow", "FlexiPage"],
-        "description": "Select which metadata types should use `sf org open --source-file` to open in the browser.",
+        "description": "Specify which metadata types are eligible to use `sf org open --source-file`. This list is only used when the below setting is enabled. Removing a type here forces the extension to resolve the metadata ID from the org instead. Available for EDIT mode only.",
         "items": {
           "type": "string",
           "enum": ["Flow", "FlexiPage"],
           "enumDescriptions": ["Flows", "FlexiPages"]
         }
       },
+
       "SalesforceMetadataOpener.enableCaching": {
         "type": "boolean",
         "default": true,
@@ -29,20 +30,22 @@
         "items": {
           "type": "string",
           "enum": [
-            "Flow",
             "Bot",
-            "Report",
             "Dashboard",
-            "ValidationRule",
-            "SObject"
+            "FlexiPage",
+            "Flow",
+            "Report",
+            "SObject",
+            "ValidationRule"
           ],
           "enumDescriptions": [
-            "Flows",
             "Agentforce Agents (Bots)",
-            "Reports",
             "Dashboards",
-            "Validation Rules",
-            "Standard and Custom Objects"
+            "FlexiPages",
+            "Flows",
+            "Reports",
+            "Standard and Custom Objects",
+            "Validation Rules"
           ]
         }
       }

--- a/scripts/manifest/contributes.json
+++ b/scripts/manifest/contributes.json
@@ -7,6 +7,16 @@
         "default": true,
         "description": "Use the `sf org open --source-file` CLI to open supported metadata in the browser. Disable this to have the extension query the org for the metadata ID instead."
       },
+      "SalesforceMetadataOpener.openFileSupportedMetadataTypes": {
+        "type": "array",
+        "default": ["Flow", "FlexiPage"],
+        "description": "Select which metadata types should use `sf org open --source-file` to open in the browser.",
+        "items": {
+          "type": "string",
+          "enum": ["Flow", "FlexiPage"],
+          "enumDescriptions": ["Flows", "FlexiPages"]
+        }
+      },
       "SalesforceMetadataOpener.enableCaching": {
         "type": "boolean",
         "default": true,

--- a/scripts/manifest/menus.json
+++ b/scripts/manifest/menus.json
@@ -20,6 +20,18 @@
       "when": "resourceFilename =~ /\\.dashboard-meta\\.xml$/",
       "group": "z_commands"
     },
+
+    {
+      "command": "extension.openFlexiPageInEditMode",
+      "when": "resourceFilename =~ /\\.flexipage-meta\\.xml$/",
+      "group": "z_commands"
+    },
+    {
+      "command": "extension.openFlexiPageInViewMode",
+      "when": "resourceFilename =~ /\\.flexipage-meta\\.xml$/",
+      "group": "z_commands"
+    },
+
     {
       "command": "extension.openFlowInEditMode",
       "when": "resourceFilename =~ /\\.flow-meta\\.xml$/",
@@ -30,6 +42,7 @@
       "when": "resourceFilename =~ /\\.flow-meta\\.xml$/",
       "group": "z_commands"
     },
+
     {
       "command": "extension.openReportInEditMode",
       "when": "resourceFilename =~ /\\.report-meta\\.xml$/",
@@ -78,6 +91,16 @@
       "command": "extension.openDashboardInViewMode",
       "when": "false"
     },
+
+    {
+      "command": "extension.openFlexiPageInEditMode",
+      "when": "false"
+    },
+    {
+      "command": "extension.openFlexiPageInViewMode",
+      "when": "false"
+    },
+
     {
       "command": "extension.openFlowInEditMode",
       "when": "false"
@@ -86,6 +109,7 @@
       "command": "extension.openFlowInViewMode",
       "when": "false"
     },
+
     {
       "command": "extension.openReportInEditMode",
       "when": "false"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Properties } from "./properties";
-import {bot, dashboard, flow, report, sobject, validationRule} from "./openers";
+import {bot, dashboard, flexipage, flow, report, sobject, validationRule} from "./openers";
 import { clearMetadataCache, displayMetadataCache } from "./salesforce/data/cache";
 
 // This method is called when your extension is activated
@@ -10,6 +10,7 @@ export function activate(context: vscode.ExtensionContext) {
   const modules = [
     { name: "Bot", handlers: bot.registerHandlers(context) },
     { name: "Dashboard", handlers: dashboard.registerHandlers(context) },
+    { name: "FlexiPage", handlers: flexipage.registerHandlers(context) },
     { name: "Flow", handlers: flow.registerHandlers(context) },
     { name: "Report", handlers: report.registerHandlers(context) },
     { name: "SObject", handlers: sobject.registerHandlers(context) },    

--- a/src/openers/factory.ts
+++ b/src/openers/factory.ts
@@ -68,7 +68,7 @@ export async function createOpenCommand<T>(
   } = options;
 
   // Check if we can use the simpler `sf open file` command based on mode and settings
-  if (shouldUseOpenFileCommand(mode, canUseOpenFileCommand)) {
+  if (mustUseOpenFileCommand(mode, metadataType, canUseOpenFileCommand)) {
     return sf.buildOpenFileCommand(filePath);
   }
 
@@ -93,21 +93,40 @@ export async function createOpenCommand<T>(
 }
 
 /**
- * Returns true if the `sf open file` command can be used for the given mode.
+ * Determines whether the `sf org open --source-file` command should be used
+ * to open metadata in the browser instead of resolving the ID manually.
+ *
+ * This decision is based on the current mode, user settings, and metadata type.
+ *
+ * @param mode - The mode in which the metadata is being opened (e.g., edit, view)
+ * @param metadataType - The metadata type (e.g., "Flow", "FlexiPage")
+ * @param canUseOpenFileCommand - Whether this metadata type *technically supports* `sf org open --source-file`
+ *                                 (defined by the caller based on extension capabilities)
+ *
+ * @returns true if the CLI open command should be used
  */
-function shouldUseOpenFileCommand(mode: OpenMode, allowed: boolean): boolean {
-  return Properties.useOpenFileCommand && allowed && AllowOpenFileMode[mode];
+function mustUseOpenFileCommand(
+  mode: OpenMode,
+  metadataType: sf.FileType,
+  canUseOpenFileCommand: boolean
+): boolean {
+  return (
+    canUseOpenFileCommand &&
+    Properties.useOpenFileCommand &&
+    Properties.openFileSupportedMetadataTypes.includes(metadataType) &&
+    AllowOpenFileMode[mode]
+  );
 }
 
 /**
- * Extracts the metadata name from the file path, based on metadata type.
+ * Extracts the metadata name from the file path, based on metadata type
  */
 function getMetadataName(filePath: string, type: sf.FileType): string {
   return utils.parseMetadataNameFromFilePath(filePath, type);
 }
 
 /**
- * Resolves the browser path using metadata context and provided file info.
+ * Resolves the browser path using metadata context and provided file info
  */
 function buildMetadataPath<T>(
   filePath: string,

--- a/src/openers/flexipage/helpers.ts
+++ b/src/openers/flexipage/helpers.ts
@@ -1,0 +1,80 @@
+import * as vscode from "vscode";
+import * as retriever from "./retriever";
+import * as handlers from "../handlers";
+import * as utils from "../../utils";
+import * as sf from "../../salesforce";
+import * as factory from "../factory";
+
+/**
+ * Registers the open handlers for the extension context
+ */
+export function registerHandlers(context: vscode.ExtensionContext) {
+  return handlers.registerHandlers(open, context);
+}
+
+/**
+ * Handles opening a FlexiPage from right-click or command palette.
+ */
+export async function open(
+  filePath: string,
+  mode: factory.OpenMode,
+  context: vscode.ExtensionContext
+): Promise<void> {
+  return handlers.openMetadata({
+    filePath,
+    mode,
+    fileType: sf.FileType.FlexiPage,
+    buildOpenCommand: getOpenCommandBuilder(context),
+  });
+}
+
+/**
+ * Returns a function that builds the open command for this opener
+ */
+function getOpenCommandBuilder(context: vscode.ExtensionContext) {
+  return async (filePath: string, mode: factory.OpenMode) => {
+    return factory.createOpenCommand(
+      filePath,
+      mode,
+      {
+        metadataType: sf.FileType.FlexiPage,
+        fetchMetadata: retriever.retrieveRecord,
+        canUseOpenFileCommand: true, // FlexiPages can use the default open file sf command
+      },
+      context
+    );
+  };
+}
+
+/**
+ * Returns the standard view URL for a FlexiPage in Setup.
+ * Example: /lightning/setup/FlexiPageList/page?address=/0M0xxxxxxx
+ */
+export function buildFlexiPageViewUrl(id: string): string {
+  return `/lightning/setup/FlexiPageList/page?address=%2F${id}`;
+}
+
+/**
+ * Builds the editable Lightning App Builder URL for a FlexiPage,
+ * with the return URL set to its view page
+ */
+export function buildFlexiPageEditUrl(id: string): string {
+  const retUrl = encodeURIComponent(buildFlexiPageViewUrl(id));
+  return `/visualEditor/appBuilder.app?id=${id}&clone=false&retUrl=${retUrl}`;
+}
+
+/**
+ * Resolves the correct Lightning path for a FlexiPage depending on mode
+ */
+export function resolvePath(ctx: utils.PathContext): string {
+  const record = ctx.metadata as sf.FlexiPage;
+  const id = record?.Id;
+
+  if (!id) {
+    throw new Error("Missing FlexiPage Id.");
+  }
+
+  return ctx.mode === factory.OpenMode.EDIT
+    ? buildFlexiPageEditUrl(id)
+    : buildFlexiPageViewUrl(id);
+}

--- a/src/openers/flexipage/retriever.ts
+++ b/src/openers/flexipage/retriever.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+import * as sf from "../../salesforce";
+
+/**
+ * Queries Salesforce to get the FlexiPage metadata using Tooling API.
+ * Caches the record ID if caching is enabled.
+ */
+export async function retrieveRecord(
+  metadataName: string,
+  metadataType: sf.FileType,
+  context: vscode.ExtensionContext
+): Promise<sf.FlexiPage | null> {
+  const result = await sf.retrieve<sf.FlexiPage>({
+    metadataName,
+    metadataType,
+    getCommand: (name) => `
+      sf data query --use-tooling-api --query "
+        SELECT Id,
+               DeveloperName,
+               MasterLabel,
+               Description, 
+               EntityDefinitionId,
+               ParentFlexiPage
+          FROM FlexiPage
+         WHERE DeveloperName = '${name}'
+         LIMIT 1" --json`,
+    parseResult: (data) => {
+      const record = data?.result?.records?.[0];
+      if (record?.Id) {
+        return {
+          Id: record.Id,
+          DeveloperName: record.DeveloperName,
+          MasterLabel: record.MasterLabel,
+          Description: record.Description,
+          EntityDefinitionId: record.EntityDefinitionId,
+          ParentFlexiPage: record.ParentFlexiPage,
+        };
+      }
+      return null;
+    },
+    context,
+  });
+
+  return result;
+}

--- a/src/openers/index.ts
+++ b/src/openers/index.ts
@@ -1,5 +1,6 @@
 export * as bot from "./bot/helpers";
 export * as dashboard from "./dashboard/helpers";
+export * as flexipage from "./flexipage/helpers";
 export * as flow from "./flow/helpers";
 export * as report from "./report/helpers";
 export * as sobject from "./sobject/helpers";

--- a/src/properties/properties.ts
+++ b/src/properties/properties.ts
@@ -35,6 +35,17 @@ export class Properties {
   }
 
   /**
+   * Returns the list of metadata types that should use `sf org open --source-file`,
+   * as defined by the user's current settings.
+   */
+  static get openFileSupportedMetadataTypes(): string[] {
+    return this.extensionConfig.get<string[]>(
+      "openFileSupportedMetadataTypes",
+      []
+    );
+  }
+
+  /**
    * Returns whether caching of record IDs is enabled.
    * This helps avoid repeated queries for the same metadata.
    */

--- a/src/salesforce/data/model.ts
+++ b/src/salesforce/data/model.ts
@@ -4,6 +4,7 @@
 export const FileType = {
   Bot: ".bot-meta.xml",
   Dashboard: ".dashboard-meta.xml",
+  FlexiPage: ".flexipage-meta.xml",
   Flow: ".flow-meta.xml",
   Report: ".report-meta.xml",
   Other: ".other-meta.xml",
@@ -21,8 +22,9 @@ export type FileType = (typeof FileType)[keyof typeof FileType];
  */
 export const MetadataLabels: Record<FileType, string> = {
   [FileType.Bot]: "Agentforce Agent (Bot)",
-  [FileType.Flow]: "Flow",
   [FileType.Dashboard]: "Dashboard",
+  [FileType.FlexiPage]: "FlexiPage",
+  [FileType.Flow]: "Flow",
   [FileType.Report]: "Report",
   [FileType.Other]: "Metadata",
   [FileType.SObject]: "Object",
@@ -33,12 +35,13 @@ export const MetadataLabels: Record<FileType, string> = {
  * Maps config keys (from user settings) to internal FileType values.
  */
 export const DeployableMetadataKeys: Record<string, FileType> = {
-  Flow: FileType.Flow,
   Bot: FileType.Bot,
-  Report: FileType.Report,
   Dashboard: FileType.Dashboard,
+  FlexiPage: FileType.FlexiPage,
+  Flow: FileType.Flow,
+  Report: FileType.Report,
+  SObject: FileType.SObject,
   ValidationRule: FileType.ValidationRule,
-  SObject: FileType.SObject
 };
 
 /**
@@ -83,6 +86,17 @@ export interface BotVersion extends MetadataRecord {
 export interface Dashboard extends MetadataRecord {
   DeveloperName?: string;
   FolderName?: string;
+}
+
+/**
+ * Interface representing the metadata of a FlexiPage retrieved from Salesforce
+ */
+export interface FlexiPage extends MetadataRecord {
+  Description?: string;
+  DeveloperName?: string;
+  EntityDefinitionId?: string;
+  MasterLabel?: string;
+  ParentFlexiPage?: string;
 }
 
 /**

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -2,12 +2,13 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { FileType } from "../salesforce";
 
-import * as flow from "../openers/flow/helpers";
 import * as bot from "../openers/bot/helpers";
-import * as report from "../openers/report/helpers";
 import * as dashboard from "../openers/dashboard/helpers";
-import * as validationRule from "../openers/validationRule/helpers";
+import * as flexipage from "../openers/flexipage/helpers";
+import * as flow from "../openers/flow/helpers";
+import * as report from "../openers/report/helpers";
 import * as sobject from "../openers/sobject/helpers";
+import * as validationRule from "../openers/validationRule/helpers";
 
 /**
  * Resolves the absolute file path from the currently active text editor in VS Code.
@@ -35,6 +36,7 @@ type ResolverFn = (ctx: PathContext) => string;
 const resolvePathMap: Record<FileType, ResolverFn> = {
   [FileType.Bot]: bot.resolvePath,
   [FileType.Dashboard]: dashboard.resolvePath,
+  [FileType.FlexiPage]: flexipage.resolvePath,
   [FileType.Flow]: flow.resolvePath,
   [FileType.Report]: report.resolvePath,
   [FileType.SObject]: sobject.resolvePath,


### PR DESCRIPTION
# 📄 Add FlexiPage Support

This PR introduces full **FlexiPage support**, along with a new configuration model for customizing which metadata types use the `sf org open --source-file` command. It also improves clarity and cohesion across settings, menus, and type handling.

---

## ✨ New Features

### ✅ FlexiPages

* Open `.flexipage-meta.xml` files in:

  * **Edit Mode** → Lightning App Builder
  * **View Mode** → FlexiPage Setup

* Automatically constructs `retUrl` to return users to FlexiPage list

* Uses Tooling API to resolve `Id` via `DeveloperName`

---

## ⚙️ New Settings

### `Metadata Types That Use CLI`

> A new per-type setting to control which metadata can use `sf org open --source-file`.

* Defaults to `["Flow", "FlexiPage"]`
* Only applies to **Edit Mode**
* When disabled for a type, the extension falls back to direct Lightning URL logic

### 🔁 Updated: `Use Sf Command To Open Metadata`

* Now acts as a global switch
* If disabled, no types will use the CLI regardless of the list above
* Description updated for clarity in the settings UI

---

## 🧼 Improvements

* 📁 Added new module: `src/openers/flexipage/` with full lifecycle support:

  * `registerHandlers()`
  * `retrieveRecord()`
  * `resolvePath()` using `retUrl`
* 🧠 `mustUseOpenFileCommand()` now checks:

  * Mode is `EDIT`
  * Global flag is on
  * Metadata type is selected in user config
  * CLI is supported for that type
* 📦 Updated `DeployableMetadataKeys` to include `"FlexiPage"`
* ✅ Added full command registration and menu integration for `.flexipage-meta.xml`

---

## 🧪 Testing

* Verified FlexiPages open in both App Builder and Setup across dev orgs
* Confirmed fallback URL behavior when CLI usage is disabled
* Validated new config schema and default values
* Ensured menus, Command Palette, and cache tooling still work as expected

---

This change lays the groundwork for future UI-based metadata like Home pages, Record Pages, and Tabs — all using the same modular pattern.